### PR TITLE
unify inline style type, inline style merge

### DIFF
--- a/packages/Button/Button.tsx
+++ b/packages/Button/Button.tsx
@@ -85,7 +85,7 @@ const Button: FunctionComponent<ButtonProps> = (props) => {
     hairline,
     color,
     icon,
-    style,
+    style = {},
     loadingText,
     children,
     dataset,
@@ -114,9 +114,8 @@ const Button: FunctionComponent<ButtonProps> = (props) => {
     ),
     hover: clsx(hoverClassName, 'van-button--active'),
   };
-  const stylesheets: Record<'container' | 'icon', CSSProperties> = {
-    // eslint-disable-next-line prefer-object-spread
-    container: Object.assign({}, style, deriveStyle(color, plain)),
+  const stylesheets: Record<string, CSSProperties> = {
+    container: { ...style, ...deriveStyle(color, plain) },
     icon: { lineHeight: 'inherit' },
   };
   // 事件绑定

--- a/packages/Cell/Cell.tsx
+++ b/packages/Cell/Cell.tsx
@@ -78,7 +78,7 @@ const Cell: FunctionComponent<CellProps> = (props) => {
     }),
     hover: clsx(hoverClassName, 'van-cell--hover'),
   };
-  const stylesheets: Record<'title', CSSProperties> = {
+  const stylesheets: Record<string, CSSProperties> = {
     title: pickStyle({
       maxWidth: titleWidth,
       minWidth: titleWidth,

--- a/packages/Checkbox/Checkbox.tsx
+++ b/packages/Checkbox/Checkbox.tsx
@@ -91,7 +91,7 @@ const Checkbox: FunctionComponent<CheckboxProps> = (props) => {
       'van-checkbox__icon--checked': checked,
     }),
   };
-  const stylesheet: Record<'iconParent' | 'icon', CSSProperties> = {
+  const stylesheets: Record<string, CSSProperties> = {
     iconParent: pickStyle({
       fontSize: iconSize,
       borderColor: color,
@@ -131,11 +131,11 @@ const Checkbox: FunctionComponent<CheckboxProps> = (props) => {
   return (
     <View className={classnames.container}>
       <View className="van-checkbox__icon-wrap" onClick={onClick}>
-        <View className={classnames.iconParent} style={stylesheet.iconParent}>
+        <View className={classnames.iconParent} style={stylesheets.iconParent}>
           <Switch>
             <Case in={visibility.customIcon}>{icon}</Case>
             <Case default>
-              <Icon name="success" size=".8em" style={stylesheet.icon} />
+              <Icon name="success" size=".8em" style={stylesheets.icon} />
             </Case>
           </Switch>
         </View>

--- a/packages/GridItem/GridItem.tsx
+++ b/packages/GridItem/GridItem.tsx
@@ -58,7 +58,7 @@ const GridItem: FunctionComponent<GridItemProps> = (props) => {
       }
     ),
   };
-  const style: Record<'view' | 'content', CSSProperties> = {
+  const style: Record<string, CSSProperties> = {
     view: pickStyle({
       width: `${100 / (columnNum as number)}%`,
       paddingTop: square ? `${100 / (columnNum as number)}%` : undefined,

--- a/packages/Icon/Icon.tsx
+++ b/packages/Icon/Icon.tsx
@@ -59,10 +59,8 @@ const Icon: FunctionComponent<IconProps> = (props) => {
   const stylesheets: Record<string, CSSProperties> = {
     container: pickStyle({
       ...style,
-      ...{
-        color,
-        fontSize: size,
-      },
+      color,
+      fontSize: size,
     }),
   };
   const visibility = {

--- a/packages/Icon/Icon.tsx
+++ b/packages/Icon/Icon.tsx
@@ -35,13 +35,20 @@ const DefaultIconProps: NeutralIconProps = {
   color: 'inherit',
 };
 
-// TODO - re-implement icon example page to be consistent with official page
-
 // Changes:
 //  1. remove class prefix;
 //  2. drop inline style value number support;
 const Icon: FunctionComponent<IconProps> = (props) => {
-  const { className, dot, info, style, name, color, size, onClick } = props;
+  const {
+    className,
+    dot,
+    info,
+    style = {},
+    name,
+    color,
+    size,
+    onClick,
+  } = props;
   const external = name.indexOf('/') !== -1;
   const classnames = {
     container: clsx(className, 'van-icon', {
@@ -49,21 +56,26 @@ const Icon: FunctionComponent<IconProps> = (props) => {
       [`van-icon-${name}`]: !external,
     }),
   };
-  const stylesheet: CSSProperties = pickStyle(
-    // shortcut method, use assign method resolve undefined style property
-    // eslint-disable-next-line prefer-object-spread
-    Object.assign({}, style, {
-      color,
-      fontSize: size,
-    })
-  );
+  const stylesheets: Record<string, CSSProperties> = {
+    container: pickStyle({
+      ...style,
+      ...{
+        color,
+        fontSize: size,
+      },
+    }),
+  };
   const visibility = {
     info: !!info || dot,
     image: external,
   };
 
   return (
-    <View style={stylesheet} className={classnames.container} onClick={onClick}>
+    <View
+      style={stylesheets.container}
+      className={classnames.container}
+      onClick={onClick}
+    >
       <Select in={visibility.info}>
         <Info className="van-icon__info" dot={dot} info={info} />
       </Select>

--- a/packages/Image/Image.tsx
+++ b/packages/Image/Image.tsx
@@ -109,12 +109,14 @@ const Image: FunctionComponent<ImageProps> = (props) => {
       'van-image--round': round,
     }),
   };
-  const stylesheet: CSSProperties = pickStyle({
-    width,
-    height,
-    borderRadius: radius,
-    overflow: radius && 'hidden',
-  });
+  const stylesheets: Record<string, CSSProperties> = {
+    container: pickStyle({
+      width,
+      height,
+      borderRadius: radius,
+      overflow: radius && 'hidden',
+    }),
+  };
   const [state, dispatch] = useReducer(
     (states: ImageState, action: ImageActions) => {
       switch (action.type) {
@@ -168,14 +170,18 @@ const Image: FunctionComponent<ImageProps> = (props) => {
     });
   }, [src]);
 
-  const visibility: Record<'image' | 'loading' | 'error', boolean> = {
+  const visibility: Record<string, boolean> = {
     image: !state.error,
     loading: state.loading && showLoading,
     error: state.error && showError,
   };
 
   return (
-    <View style={stylesheet} className={classnames.container} onClick={onClick}>
+    <View
+      style={stylesheets.container}
+      className={classnames.container}
+      onClick={onClick}
+    >
       <Select in={visibility.image}>
         <WechatImage
           className="van-image__img"

--- a/packages/Loading/Loading.tsx
+++ b/packages/Loading/Loading.tsx
@@ -52,7 +52,7 @@ const Loading: FunctionComponent<LoadingProps> = (props) => {
       'van-loading__spinner--circular': type === 'circular',
     }),
   };
-  const stylesheets: Record<'spinner' | 'text', CSSProperties> = {
+  const stylesheets: Record<string, CSSProperties> = {
     spinner: pickStyle({
       color,
       width: size,

--- a/packages/Progress/Progress.tsx
+++ b/packages/Progress/Progress.tsx
@@ -54,7 +54,7 @@ const Progress: FunctionComponent<ProgressProps> = (props) => {
     container: clsx(className, 'van-progress'),
     tracker: 'van-progress__portion',
   };
-  const style: Record<'container' | 'tracker' | 'censor', CSSProperties> = {
+  const style: Record<string, CSSProperties> = {
     container: {
       height: strokeWidth,
       background: trackColor,

--- a/packages/SidebarItem/SidebarItem.tsx
+++ b/packages/SidebarItem/SidebarItem.tsx
@@ -51,7 +51,7 @@ const SidebarItem: FunctionComponent<SidebarItemProps> = (props) => {
     // original code
     info: info || dot,
   };
-  const stylesheets: Record<'info', CSSProperties> = {
+  const stylesheets: Record<string, CSSProperties> = {
     info: {
       right: '4px;',
     },

--- a/packages/Slider/Slider.tsx
+++ b/packages/Slider/Slider.tsx
@@ -88,7 +88,7 @@ const Slider: FunctionComponent<SliderProps> = (props) => {
       'van-slider--disabled': disabled,
     }),
   };
-  const stylesheets: Record<'container' | 'bar', CSSProperties> = {
+  const stylesheets: Record<string, CSSProperties> = {
     // for outer view container
     container: pickStyle({
       backgroundColor: inactiveColor,

--- a/packages/Stepper/Stepper.tsx
+++ b/packages/Stepper/Stepper.tsx
@@ -80,7 +80,7 @@ const Stepper: FunctionComponent<StepperProps> = (props) => {
   } = props;
   const type = integer ? 'number' : 'digit';
 
-  const stylesheets: Record<'button', CSSProperties> = {
+  const stylesheets: Record<string, CSSProperties> = {
     button: pickStyle({
       width: buttonSize,
       height: buttonSize,

--- a/packages/Steps/Steps.tsx
+++ b/packages/Steps/Steps.tsx
@@ -73,7 +73,7 @@ const Steps: FunctionComponent<StepsProps> = (props) => {
     const status =
       // eslint-disable-next-line no-nested-ternary
       index < active ? 'finish' : index === active ? 'process' : 'inactive';
-    const stylesheets: Record<'container' | 'title' | 'line', CSSProperties> = {
+    const stylesheets: Record<string, CSSProperties> = {
       container: pickStyle({
         color: status === 'inactive' ? inactiveColor : undefined,
       }),


### PR DESCRIPTION
+ Unify Type

```typescript
// before
const style: Record<'view' | 'content', CSSProperties> = {};
// after
const style: Record<string, CSSProperties> = {};
```

+ Unify Style Merge

```typescript
// before
const stylesheets = {
  container: Object.assign({}, style,  { color })
};
// after
const { style = {} } = props;
const stylesheets = {
  container: { ...style, color }
};
```